### PR TITLE
Add custom event triggers for the sh-link elements that are triggered when it's shown, hidden, and simply toggled.

### DIFF
--- a/wp-showhide.php
+++ b/wp-showhide.php
@@ -100,13 +100,16 @@ function showhide_footer() {
 				}
 				if($toggle.text() === more_text) {
 					$toggle.text(less_text);
+					$link.trigger( "sh-link:more" );
 				} else {
 					$toggle.text(more_text);
+					$link.trigger( "sh-link:less" );
 				}
+				$link.trigger( "sh-link:toggle" );
 			}
 		</script>
 	<?php else : ?>
-		<script type="text/javascript">function showhide_toggle(a,b,d,f){var e=jQuery("#"+a+"-link-"+b),c=jQuery("a",e),g=jQuery("#"+a+"-content-"+b);a=jQuery("#"+a+"-toggle-"+b);e.toggleClass("sh-show sh-hide");g.toggleClass("sh-show sh-hide").toggle();"true"===c.attr("aria-expanded")?c.attr("aria-expanded","false"):c.attr("aria-expanded","true");a.text()===d?a.text(f):a.text(d)};</script>
+		<script type="text/javascript">function showhide_toggle(e,t,r,g){var a=jQuery("#"+e+"-link-"+t),s=jQuery("a",a),i=jQuery("#"+e+"-content-"+t),l=jQuery("#"+e+"-toggle-"+t);a.toggleClass("sh-show sh-hide"),i.toggleClass("sh-show sh-hide").toggle(),"true"===s.attr("aria-expanded")?s.attr("aria-expanded","false"):s.attr("aria-expanded","true"),l.text()===r?(l.text(g),a.trigger("sh-link:more")):(l.text(r),a.trigger("sh-link:less")),a.trigger("sh-link:toggle")}</script>
 	<?php endif; ?>
 <?php
 }


### PR DESCRIPTION
Adding triggers on the `.sh-link` element for `sh-link:toggle`, `sh-link:more`, and `sh-link:less` makes it so developers can make stuff happen on those different events.

For example, I have a site which uses the EqualHeights script to make content areas the same height, but I also need the heights to update once I have WP-ShowHide toggle content to be shown/hidden (there didn't seem to be any way to accommodate this).

As such, I modified the showhide_toggle script's output to include these 3 new custom events (I only needed one for my purpose [toggle], but I figured there'd be no harm in adding the other two as well). Then, I implemented the following code on my site to have EqualHeights update whenever a sh-link is toggled.
```
$('body').on('sh-link:toggle','.sh-link',function(){
	$(window).trigger('equalheights');
});
```

As an aside, `$('body').on('sh-link:more','.sh-link',function(){alert('Now showing more');});` and `$('body').on('sh-link:less','.sh-link',function(){alert('Now showing less');});` is example code for seeing how the more & less events are handled.

I would love to see this added officially in a future version release as I really do need to make other events happen when a sh-link is toggled. Thanks for the great plugin!